### PR TITLE
rm pf external server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,8 +34,11 @@ services:
     image: pingidentity/pingfederate:edge
     command: wait-for pingdirectory:389 -t 300 -- entrypoint.sh start-server
     environment:
-    - SERVER_PROFILE_URL=https://github.com/cprice-ping/PFExternalConsent.git
-    - SERVER_PROFILE_PATH=pf
+      - PING_IDENTITY_DEVOPS_USER=${PING_IDENTITY_DEVOPS_USER}
+      - PING_IDENTITY_DEVOPS_KEY=${PING_IDENTITY_DEVOPS_KEY}
+      - PING_IDENTITY_ACCEPT_EULA=YES
+      - SERVER_PROFILE_URL=https://github.com/cprice-ping/PFExternalConsent.git
+      - SERVER_PROFILE_PATH=pf
     
     #volumes:
     #  - ${HOME}/projects/devops/volumes/full-stack.pingfederate:/opt/out
@@ -50,12 +53,15 @@ services:
   pingdirectory:
     image: pingidentity/pingdirectory:edge
     environment:
-    - SERVER_PROFILE_URL=https://github.com/cprice-ping/PFExternalConsent.git
-    - SERVER_PROFILE_PATH=pd
-    - SERVER_PROFILE_PARENT=BASELINE
-    - SERVER_PROFILE_BASELINE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
-    - SERVER_PROFILE_BASELINE_PATH=baseline/pingdirectory
-
+      - PING_IDENTITY_DEVOPS_USER=${PING_IDENTITY_DEVOPS_USER}
+      - PING_IDENTITY_DEVOPS_KEY=${PING_IDENTITY_DEVOPS_KEY}
+      - PING_IDENTITY_ACCEPT_EULA=YES
+      - SERVER_PROFILE_URL=https://github.com/cprice-ping/PFExternalConsent.git
+      - SERVER_PROFILE_PATH=pd
+      - SERVER_PROFILE_PARENT=BASELINE
+      - SERVER_PROFILE_BASELINE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
+      - SERVER_PROFILE_BASELINE_PATH=baseline/pingdirectory
+      
     #volumes:
     #  - ${HOME}/projects/devops/volumes/full-stack.pingdirectory:/opt/out
     #  - ${HOME}/projects/devops/pingidentity-server-profiles/baseline/pingdirectory:/opt/in

--- a/pd/pd.profile/dsconfig/92-accessTokenValidator.dsconfig
+++ b/pd/pd.profile/dsconfig/92-accessTokenValidator.dsconfig
@@ -1,6 +1,6 @@
 dsconfig set-trust-manager-provider-prop --provider-name "Blind Trust" --set enabled:true
 
-dsconfig create-external-server --server-name PingFederate --type http --set base-url:https://pingfederate:9031 --set hostname-verification-method:allow-all --set key-manager-provider:Null --set "trust-manager-provider:Blind Trust"
+# dsconfig create-external-server --server-name PingFederate --type http --set base-url:https://pingfederate:9031 --set hostname-verification-method:allow-all --set key-manager-provider:Null --set "trust-manager-provider:Blind Trust"
 
 dsconfig create-access-token-validator --validator-name PingFederate --type ping-federate --set "identity-mapper:Exact Match" --set subject-claim-name:sub --set enabled:true --set authorization-server:PingFederate --set client-id:PingIntrospect --set "client-secret:AAAAganjFSgi1ivCiep+ERudDNotU3Y5V2M="
 


### PR DESCRIPTION
- removed the redundant create external PF server and tested that PD/PF stand up, was also able to curl the url in the README.md
- added devops vars to ping-product services so they can get licenses. 